### PR TITLE
adjusted bottom margin, color

### DIFF
--- a/assets/scss/_skeletons.scss
+++ b/assets/scss/_skeletons.scss
@@ -15,14 +15,16 @@ $header-line-widths: (
   "full": 100%,
 );
 
+$skeleton-color: #EFEFEF;
+
 .skeleton {
   &__header {
     box-sizing: border-box;
     height: 1em;
-    background: #cdcdcd;
+    background: darken($skeleton-color, 5%);
     border-radius: 3px;
     overflow: hidden;
-    margin: 0 0 0.6rem 0;
+    margin: 0 0 0.8em 0;
     font-size: map-get($headers, "h1");
     width: map-get($header-line-widths, "full");
 
@@ -48,12 +50,9 @@ $header-line-widths: (
     box-sizing: border-box;
     width: 100%;
     height: 1.2rem;
-    margin-bottom: 0.6em;
-    background: #ddd;
+    margin-bottom: 0.6rem;
+    background: $skeleton-color;
     border-radius: 3px;
-    &:last-child {
-      margin-bottom: 0;
-    }
   }
 
   // This means if there is only 1 line it will be full width, otherwise the last-child will only be 50% width


### PR DESCRIPTION
As discussed in meeting:
- Increased bottom margin on last line of paragraph skeletons
- Increased bottom margin on last line of header skeletons
- Added $skeleton-color Sass variable to set color
  - Use sass darken() to apply 5% darker $skeleton-color to headers for SLIGHT visual difference

Screenshot:
![Screen Shot 2020-12-08 at 3 51 27 PM](https://user-images.githubusercontent.com/5217768/101539915-3ea2b080-396d-11eb-8dcc-1792b457cedc.png)
