### PR TITLE
Removing unused src attributes from img in markup

### DIFF
--- a/content/docs/components/image-round.md
+++ b/content/docs/components/image-round.md
@@ -24,13 +24,13 @@ Circular pills can also have images.
 <div class="mt-3 mb-4">
 {{< highlight html >}}
 <div class="image--round-small">
-  <img src="https://images.unsplash.com/photo-1565191999001-551c187427bb?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60" alt="pretty">
+  <img src="..." alt="pretty">
 </div>
 <div class="image--round-medium">
-  <img src="https://images.unsplash.com/photo-1565191999001-551c187427bb?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60" alt="pretty">
+  <img src="..." alt="pretty">
 </div>
 <div class="image--round-large">
-  <img src="https://images.unsplash.com/photo-1565191999001-551c187427bb?ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60" alt="pretty">
+  <img src="..." alt="pretty">
 </div>
 {{< /highlight >}}
 </div>


### PR DESCRIPTION
- Removed unused `src` attributes from `img` tags in markup because the images are now skeleton images
- Staying consistent with other markup examples where skeleton images are used 