### PR TITLE
Styleguide - Remove Post List documentation

### DIFF
--- a/content/docs/components/lists.md
+++ b/content/docs/components/lists.md
@@ -179,20 +179,3 @@ Using our utilities, icons, and modifiers, you can create some pretty fancy list
 </ul>
 {{< /highlight >}}
 </div>
-
-
-## Post Lists
-
-<div class="block-4 mb-3">
-  <div class="pill text--size-xs background-negative inverted no-border">
-    <i class="pi-flag mr-1"></i>
-    Deprecated v1.1.15
-  </div> 
-</div>
-This list style is deprecated as of v1.1.15. To see how to recreate this look using utility classes, see our example above.
-
-A `post-list` is a pretty basic list. The margin and padding is removed from the list itself. The `post-item`s which should be added to the `li`s in the list, have a `padding-bottom: 1rem` and `margin-bottom: 1rem`.
-
-Adding the class `post-list--inline` gives the list an inline look using `display: flex`.
-
-You can add some arrow icons to be in front of each `li` by adding the class `post-list--arrow`.

--- a/layouts/partials/site/footer.html
+++ b/layouts/partials/site/footer.html
@@ -6,10 +6,8 @@
                     <img src="/images/platform-ui.svg" class="h-25" alt=" Platform UI">
                 </a>
                 <span class="text--size-xl">Platform UI</span>
-                <p>Built by the <a class="text-beige" href="{{ .Site.Params.rim_url }}" target="_blank">{{
-                        .Site.Params.rim }}</a>
-                    development team, aka <a class="text-beige" href="{{ .Site.Params.rimdev_url }}">{{
-                        .Site.Params.rimdev }}</a>, to
+                <p>Built by the <a class="text-beige" href="{{ .Site.Params.rim_url }}" target="_blank">{{ .Site.Params.rim }}</a>
+                    development team, aka <a class="text-beige" href="{{ .Site.Params.rimdev_url }}">{{ .Site.Params.rimdev }}</a>, to
                     power our platform of staff and agent tools. </p>
             </div>
             <p>Platform UI is available on <a class="text-beige"


### PR DESCRIPTION
Issue:
#89 

Updates:
- Removed Post-list documentation from styleguide
- Fixed issue with broken template tag in footer