### PR TITLE
Truncate With Ellipsis: Shrink width of containers to show effect in examples at larger screen sizes

### DIFF
--- a/content/docs/utilities/truncate-with-ellipsis.md
+++ b/content/docs/utilities/truncate-with-ellipsis.md
@@ -6,8 +6,10 @@ A utility that does what it's name says. It truncates text within an element wit
 
 This can be done by adding the class `truncate-with-ellipsis`
 
-<div class="w-25">
-    <h3 class="truncate-with-ellipsis">This is a heading for a block</h3>
+<div class="block-container">
+    <div class="block block-6 tablet-up-3">
+        <h3 class="truncate-with-ellipsis">This is a heading for a block</h3>
+    </div>
 </div>
 
 <div class="mt-3 mb-4">
@@ -25,6 +27,8 @@ This can be done by adding the class `truncate-with-ellipsis`
 
 <button class="button button--primary background-salmon text-white has-text button--lg ellipsis-button">Toggle Ellipsis</button>
 
-<div class="w-25">
-    <h3 class="truncate-with-ellipsis ellipsis-header">This is a heading for a block</h3>
+<div class="block-container">
+    <div class="block block-6 tablet-up-3">
+        <h3 class="truncate-with-ellipsis ellipsis-header">This is a heading for a block</h3>
+    </div>
 </div>


### PR DESCRIPTION
#121

Shrink the width of the containers so the truncate with ellipsis effect is shown at larger screen sizes.

![image](https://user-images.githubusercontent.com/18554928/159349565-f74de955-0999-439f-944a-7e0cdd58475b.png)
