### PR TITLE
Update Mobile Nav + few extras

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,48 +1,55 @@
 window.addEventListener('DOMContentLoaded', (event) => {
-  const toc = document.querySelector('#on-this-page');
+  const tocs = document.querySelectorAll('.on-this-page');
   const main = document.querySelector('main');
+  
+  if (tocs) {
+    tocs.forEach(toc => {
+      const headings = main.querySelectorAll('h2,h3');
+      
+      let tocList = document.createElement('ul');
+      tocList.classList.add('list');
 
-  if (toc) {
-    const headings = main.querySelectorAll('h2,h3');
-    let tocList = document.createElement('ul');
-    tocList.classList.add('list');
+      headings.forEach(heading => {
+        if (heading.innerText !== 'On This Page') {
+          if (heading.classList.contains('page-anchor-target')) heading.innerHTML = `<a href="#${heading.id}">${heading.innerText}</a>`;
 
-    headings.forEach((heading) => {
-      let li = document.createElement('li');
-      if (heading.localName === 'h3') {
-        li.className = 'pl-3';
-      }
-      let a = document.createElement('a');
-      if (heading.id) {
-        heading.classList.add('page-anchor-target');
-        a.setAttribute('href', '#' + heading.id);
-        a.className = 'text-base text-light--hover toc-link';
-        a.textContent = heading.innerText;
-        li.append(a);
-        tocList.append(li);
-      }
-    });
-
-    if (tocList.childNodes.length == 0) {
-      document.querySelector('#content-nav').remove();
-    }
-
-    toc.append(tocList);
-
-    const tocLink = document.querySelectorAll('.toc-link');
-
-    if (tocLink) {
-      tocLink.forEach((link) => {
-        link.addEventListener('click', () => {
-          tocLink.forEach((elm) => {
-            elm.classList.remove('text--bold');
-          });
-          link.classList.add('text--bold');
-        });
+          let li = document.createElement('li');
+          if (heading.localName === 'h3') li.classList.add('pl-3');
+  
+          let a = document.createElement('a');
+          if (heading.id) {
+            heading.classList.add('page-anchor-target');
+            a.setAttribute('href', `#${heading.id}`);
+            a.classList = ['text-light-purple', 'text-purple--hover', 'toc-link'].join(' ');
+            a.textContent = heading.innerText;
+          }
+          li.appendChild(a);
+          tocList.appendChild(li);
+        }
       });
-    }
+
+      if (tocList.childNodes.length == 0) {
+        const contentNavs = document.querySelectorAll('.content-nav');
+        contentNavs.forEach(nav => nav.remove());
+      };
+      
+      toc.appendChild(tocList);
+    })
   }
 
+  const tocLink = document.querySelectorAll('.toc-link');
+
+  if (tocLink) {
+    tocLink.forEach((link) => {
+      link.addEventListener('click', () => {
+        tocLink.forEach((elm) => {
+          elm.classList.remove('text--bold');
+        });
+        link.classList.add('text--bold');
+      });
+    });
+  }
+  
   const table = main.querySelectorAll('table');
 
   if (table) {
@@ -259,5 +266,5 @@ if (codeExamples) {
   }
 }
 
-const mobileNavButton = document.querySelector('.site-menu-mobile-action');
-mobileNavButton.addEventListener('click', () => mobileNavButton.classList.toggle('active'));
+// const mobileNavButton = document.querySelector('.site-menu-mobile-action');
+// mobileNavButton.addEventListener('click', () => mobileNavButton.classList.toggle('active'));

--- a/assets/scss/_config.scss
+++ b/assets/scss/_config.scss
@@ -62,13 +62,13 @@ $brand-colors: (
   }
 }
 
-#frame-mobile-nav-drawer{
-  width:75%;
-}
-
 #frame-mobile-nav-trigger{
   border-top-left-radius:0;
   border-bottom-left-radius:0;
+}
+
+.mobile-menu-action{
+  z-index:50;
 }
 
 #content {
@@ -78,7 +78,7 @@ $brand-colors: (
   }
 }
 
-#content-nav {
+.content-nav {
   order: 1;
   @media screen and (min-width:991px){
     padding-top:1em;
@@ -133,4 +133,44 @@ $brand-colors: (
 @keyframes float-away {
   from {transform: translate(0, 0) rotate(0)}
   to {transform: translate(150%, 25%) rotate(1000deg)}
+}
+
+main {
+  a:not(.accordion > a, .button, .skeleton > a, .message > a){
+    color:var(--light-purple);
+    border-bottom:1px solid var(--light-purple);
+    &:hover{
+      color:var(--purple);
+      border-bottom:1px solid var(--purple);
+    }
+  }
+  a[rel="external"]{
+    &::after{
+      font-family:'platform-icons';
+      content: "\f17c";
+      font-size:0.75rem;
+      margin-left:0.25rem;
+      text-decoration: none;
+    }
+  }
+  .page-anchor-target{
+    color:var(--purple);
+    a{
+      $self: &;
+      border-bottom:none !important;
+      transition: none !important;
+      &:hover{
+        border-bottom:1px solid var(--purple) !important;
+      }
+      &:hover::before{
+        font-family:'platform-icons';
+        font-size:1.25rem;
+        position: absolute;
+        content:"\f17d";
+        color:var(--light-purple);
+        margin-left:-1.55rem;
+        margin-top: 0.35rem;
+      }
+    }
+  }
 }

--- a/assets/scss/_utilities.scss
+++ b/assets/scss/_utilities.scss
@@ -7,4 +7,9 @@
     .text-#{$name} {
         color: $color !important;
     }
+    .text-#{$name}--hover {
+        &:hover{
+            color: $color !important;
+        }
+    }
 }

--- a/content/docs/components/buttons.md
+++ b/content/docs/components/buttons.md
@@ -5,7 +5,7 @@ date: 2018-07-20T12:59:15-04:00
 
 Each button has a default button style. Color can be added to any button using a combination of background and text utilities.
 
-Add icons to buttons using [platform icons](https://github.com/ritterim/platform-icons) icons: `<i class="pi-plus"></i>`
+Add icons to buttons using <a href="https://github.com/ritterim/platform-icons" rel="external" target="_blank">platform icons</a> icons: `<i class="pi-plus"></i>`
 
 The default platform button. Usually paired visually with an icon. Can be the default size or large.
 

--- a/content/docs/getting-started/accessibility.md
+++ b/content/docs/getting-started/accessibility.md
@@ -4,7 +4,7 @@ date: 2018-07-20T12:59:15-04:00
 weight: 4
 ---
 
-Accessibility was on our minds while building Platform UI. You can use this framework to create a number of different components and layouts for your site that is both visually appealing and functional. Most of our components are accessible right out of the box, but given the flexibility of the framework, it can be easy to ignore accessibility and build a site that may not meet the accessibility standards of [WCAG 2.0](https://www.w3.org/TR/WCAG20/).
+Accessibility was on our minds while building Platform UI. You can use this framework to create a number of different components and layouts for your site that is both visually appealing and functional. Most of our components are accessible right out of the box, but given the flexibility of the framework, it can be easy to ignore accessibility and build a site that may not meet the accessibility standards of <a href="https://www.w3.org/TR/WCAG20/" rel="external" target="_blank">WCAG 2.0</a>.
  
 Although we built Platform UI with accessibility in mind, it is important that you not rely on the framework entirely. The overall accessibility of your site will depend largely on your markup, extra styling, and or scripts added.
  
@@ -29,11 +29,11 @@ Content that should be made accessible to screen readers, but is not necessary f
 </button>
 {{< /highlight >}}
  
-On the flip side, sometimes it can be necessary to hide content from a screen reader. Take the button example above. Notice the `aria-hidden=”true”`. In this case, we’re hiding decorative content from a screen reader. You can use [WAI-ARIA](https://www.w3.org/WAI/standards-guidelines/aria/) roles and attributes to improve the experience of a screen reader.
+On the flip side, sometimes it can be necessary to hide content from a screen reader. Take the button example above. Notice the `aria-hidden=”true”`. In this case, we’re hiding decorative content from a screen reader. You can use <a href="https://www.w3.org/WAI/standards-guidelines/aria/" rel="external" target="_blank">WAI-ARIA</a> roles and attributes to improve the experience of a screen reader.
  
  
 ## Further Reading
-- [A11Y Project](https://a11yproject.com/)
-- [MDN Accessibility](https://developer.mozilla.org/en-US/docs/Web/Accessibility)
-- [MDN Aria](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA)
-- [WebAIM Color Checker](https://webaim.org/resources/contrastchecker/)
+- <a href="https://a11yproject.com/" rel="external" target="_blank">A11Y Project</a>
+- <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility" rel="external" target="_blank">MDN Accessibility</a>
+- <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA" rel="external" target="_blank">MDN Aria</a>
+- <a href="https://webaim.org/resources/contrastchecker/" rel="external" target="_blank">WebAIM Color Checker</a>

--- a/content/docs/getting-started/get-started.md
+++ b/content/docs/getting-started/get-started.md
@@ -4,13 +4,13 @@ date: 2018-07-20T12:59:15-04:00
 weight: 1
 ---
 ## Prologue
-As part of [Ritter Insurance Marketing](https://ritterim.com)'s software development team, RIMdev, our frontend folks started Platform UI as a CSS framework for faster, more efficient development. Our suite of agent and staff tools have benefitted greatly, along with our team.
+As part of the <a href="https://ritterim.com/" rel="external" target="_blank">Ritter Insurance Marketing</a> software development team, RIMdev, our frontend folks started Platform UI as a CSS framework for faster, more efficient development. Our suite of agent and staff tools have benefitted greatly, along with our team.
 
 Platform UI has evolved in scope to include a base icon font family, Platform Icons, UI kits based in Adode XD, and, our philosophies and practices SPAs, static sites, and application development. 
 
 We hope you find it as useful and easy to use as we do.
 
-If you're not downloading or building, then CDN access via [UNPKG](https://unpkg.com/) is fast and easy to start working with Platform UI in your project!
+If you're not downloading or building, then CDN access via <a href="https://www.unpkg.com/" rel="external" target="_blank">UNPKG</a> is fast and easy to start working with Platform UI in your project!
 
 ## CSS
 
@@ -102,11 +102,11 @@ There are a few third party choices we've incorporated into Platform UI, these a
 
 ### Animate.css
 
-We started to build our own animations, but why bother when [Animate.css](https://daneden.github.io/animate.css/) is around? It fits all of our needs and plays nicely with VueJS. 
+We started to build our own animations, but why bother when <a href="https://daneden.github.io/animate.css/" rel="external" target="_blank">Animate.css</a> is around? It fits all of our needs and plays nicely with VueJS. 
 
 **If you're using Platform UI in your own build process, you'll need to include Animate.css.**
 
-For a list of supported More from the Animate.css [docs](https://github.com/daneden/animate.css#animatecss------).
+For a list of supported More from the Animate.css <a href="https://github.com/daneden/animate.css#animatecss------" rel="external" target="_blank">docs</a>.
 
 Simple usage:
 
@@ -130,19 +130,19 @@ Combining Animate.css with Vue transitions:
 
 ### Highlight.js
 
-Platform UI handles inline code, `<code></code>`, highlights, however we leverage [Highlight.js](https://highlightjs.org/) during the build to add a more complete syntax highlighting solutions. 	 
+Platform UI handles inline code, `<code></code>`, highlights, however we leverage <a href="https://highlightjs.org/" rel="external" target="_blank">Highlight.js</a> during the build to add a more complete syntax highlighting solutions. 	 
 
 **If you're using Platform UI in your own build process, you'll need to include Normalize.css.**
 
 ### Normalize.css
 
-The nature of browsers and their vendors often require a reset to normalize behavious for standard HTML tags, so we include [Normalize.css](https://necolas.github.io/normalize.css/) as part of Patform UIs build process.
+The nature of browsers and their vendors often require a reset to normalize behavious for standard HTML tags, so we include <a href="https://necolas.github.io/normalize.css/" rel="external" target="_blank">Normalize.css</a> as part of Platform UIs build process.
 
 **If you're using Platform UI in your own build process, you'll need to include Normalize.css.**
 
 ### Postcss
 
-In the same spirit as Normalize.css, we also leverage [Postcss](https://github.com/postcss/postcss) and [Autoprefixer](https://github.com/postcss/autoprefixer) to reduce browser inconsistencies. 
+In the same spirit as Normalize.css, we also leverage <a href="https://github.com/postcss/postcss" rel="external">Postcss</a> and <a href="https://github.com/postcss/autoprefixer" rel="external" target="_blank">Autoprefixer</a> to reduce browser inconsistencies. 
 
 **If you're using Platform UI in you're own build process, you'll need to include Postcss. Likewise, if you prefer greater browser support, you will have to build Platform UI from source.**
 

--- a/content/docs/getting-started/installation.md
+++ b/content/docs/getting-started/installation.md
@@ -30,7 +30,7 @@ You can also download the source files, uncompiled Sass and JS, to compile on yo
 NPM
 {{< /heading >}}
 
-Add Platform UIs source files to your build. [Autoprefixer](https://github.com/postcss/autoprefixer), [Normalize](https://github.com/necolas/normalize.css/), and version 1.23 or higher of the [Sass](https://www.npmjs.com/package/sass) compiler will be needed to successfully build Platform UI.
+Add Platform UIs source files to your build. <a href="https://github.com/postcss/autoprefixer" rel="external" target="_blank">Autoprefixer</a>, <a href="https://github.com/necolas/normalize.css/" rel="external" target="_blank">Normalize</a>, and version 1.23 or higher of the <a href="https://www.npmjs.com/package/sass" rel="external" target="_blank">Sass</a> compiler will be needed to successfully build Platform UI.
 
 <div class="mb-3">
 {{< highlight bash >}}
@@ -42,7 +42,7 @@ $ npm install @ritterim/platform-ui
 CDN
 {{< /heading >}}
 
-While we don't host a dedicated CDN version of Platform UI, if you prefer, you can always access any npm package using [UNPKG](https://unpkg.com/).
+While we don't host a dedicated CDN version of Platform UI, if you prefer, you can always access any npm package using <a href="https://unpkg.com/" rel="external" target="_blank">UNPKG</a>.
 
 {{< heading heading="h2" id="theming">}}
 Theming

--- a/content/docs/layout/flex.md
+++ b/content/docs/layout/flex.md
@@ -136,27 +136,27 @@ Sets individual elements to align to either the start, center, end, or baseline 
   <div class="actions block h-10">
     <ul class="list">
       <li>
-        <button class="button button--purple " data-class="flex--justify-start">
+        <button class="button button--purple" data-children="3" data-class="flex--justify-start">
           <pre>.flex--justify-start</pre>
         </button>
       </li>
       <li>
-        <button class="button button--purple " data-class="flex--justify-center">
+        <button class="button button--purple" data-children="3" data-class="flex--justify-center">
           <pre>.flex--justify-center</pre>
         </button>
       </li>
       <li>
-        <button class="button button--purple " data-class="flex--justify-end">
+        <button class="button button--purple" data-children="3" data-class="flex--justify-end">
           <pre>.flex--justify-end</pre>
         </button>
       </li>
       <li>
-        <button class="button button--purple " data-children="3" data-class="flex--justify-around">
+        <button class="button button--purple" data-children="3" data-class="flex--justify-around">
           <pre>.flex--justify-around</pre>
         </button>
       </li>
       <li>
-        <button class="button button--purple " data-children="3" data-class="flex--justify-between">
+        <button class="button button--purple" data-children="3" data-class="flex--justify-between">
           <pre>.flex--justify-between</pre>
         </button>
       </li>
@@ -164,6 +164,8 @@ Sets individual elements to align to either the start, center, end, or baseline 
   </div>
   <div class="results block background-dark p-2">
     <div class="example" data-defaults="flex">
+      <div class="example-element border border--color-white background-light-purple"></div>
+      <div class="example-element border border--color-white background-light-purple"></div>
       <div class="example-element border border--color-white background-light-purple"></div>
     </div>
   </div>

--- a/content/docs/utilities/backgrounds.md
+++ b/content/docs/utilities/backgrounds.md
@@ -83,7 +83,7 @@ You can use platform UI to add background images using data attributes and some 
 
 For starters, you'll need to add the class `background-image` onto the element where you want to use add an image. From there, use data attributes to change the look of the background image.
 
-See the example below to see it all come together. You may notice a `ratio-` class on the image container. We talk more about that [here](https://style.rimdev.io/section-utilities.html#utilities-backgroundratio).
+See the example below to see it all come together. You may notice a `ratio-` class on the image container. We talk more about that <a href="https://style.rimdev.io/section-utilities.html#utilities-backgroundratio" rel="external" target="_blank">here</a>.
 
 <div class="overflow-x--auto">
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,14 +1,16 @@
 {{ define "main" }}
 <div class="block-container laptop-up-2 p-5">
   <div class="block">
-  <h1>{{ .Title }}</h1>
-  {{ range (.Paginator 20).Pages }}
-  <article class="py-4">
-    <h3><a href="{{ .Permalink }}">{{ .Title }}</a></h3>
-    <p>{{ .Summary }}</p>
-    <a href="{{ .Permalink }}">Learn More &raquo;</a>
-  </article>
-  {{ end }}
+    <h1>{{ .Title }}</h1>
+    <main>
+      {{ range (.Paginator 20).Pages }}
+      <article class="py-4">
+        <h3><a href="{{ .Permalink }}">{{ .Title }}</a></h3>
+        <p>{{ .Summary }}</p>
+        <a href="{{ .Permalink }}">Learn More &raquo;</a>
+      </article>
+      {{ end }}
+    </main>
   </div>
 </div>
 {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -3,21 +3,21 @@
   <div id="frame" class="block-container w-100">
     {{ if not .IsHome }}
     <!-- Mobile Nav & Trigger -->
-    <div id="frame-mobile-nav" class="hide-lg-tablet-up py-4 px-0">
-      <button id="frame-mobile-nav-trigger"
-          class="mobile-menu-action button button--lg background-lighter border--color-lighter text-base drawer__open"
-          data-drawer="frame-mobile-nav-drawer">
-          Table of Contents
-          <div class="pill pill--circle text-white background-light ml-2">
-              <i class="pi-angle-right" aria-hidden="true"></i>
-          </div>
-      </button>
-      <div id="frame-mobile-nav-drawer" class="drawer drawer--closed drawer-left animated slideInLeft fastest">
-        <div class="drawer__inner animated slideInLeft fastest">
+    <div id="frame-mobile-nav" class="hide-lg-tablet-up px-0">
+      <div class="block-container background-lighter flex--justify-end py-2 px-4">
+        <button class="button--plain flex flex--align-center flex--column drawer__open" data-drawer="frame-mobile-nav-drawer">
+          <i class="pi-menu pi-lg" aria-hidden="true"></i>
+          Docs
+        </button>
+      </div>
+      <div id="frame-mobile-nav-drawer" class="drawer drawer-left">
+        <div class="drawer__inner">
           <div class="drawer__content p-0">
-            <div class="flex flex--justify-end my-3 mr-2">
-                <button class="button drawer__close mobile-menu-action"
-                    data-drawer="frame-mobile-nav-drawer">
+            <div class="flex flex--justify-end mr-2">
+                <button 
+                  class="button button--secondary has-text drawer__close mobile-menu-action m-2 pos-fix pin-right"
+                  data-drawer="frame-mobile-nav-drawer"
+                >
                     Close
                     <i class="pi-times" aria-hidden="true"></i>
                 </button>
@@ -39,14 +39,20 @@
     {{ end }}
     <main id="frame-content" class="block-container w-100{{ if not .IsHome }} lg-tablet-up-10{{ end }}">
       <article id="content" class="w-100{{ if not .IsHome }} lg-tablet-up-9 laptop-up-10 px-4 pb-4{{ end }}">
-        <h1>{{ .Title }}</h1>
+        <h1 class="text-purple">{{ .Title }}</h1>
+        <aside class="content-nav hide-lg-tablet-up background-lighter p-3 mb-4">
+        <nav role="sidebar" id="sidebar-right">
+          <h2 class="text--size-lg">On This Page</h2>
+          <div id="on-this-page" class="on-this-page"></div>
+        </nav>
+      </aside>
         {{ .Content }}
       </article>
       {{ if not .IsHome }}
-      <aside id="content-nav" class="tablet-up-4 lg-tablet-up-3 laptop-up-2 pr-4">
+      <aside class="content-nav hide-lg-tablet-down tablet-up-4 lg-tablet-up-3 laptop-up-2 pr-4">
         <nav role="sidebar" id="sidebar-right">
           <h2 class="text--size-lg">On This Page</h2>
-          <div id="on-this-page"></div>
+          <div id="on-this-page" class="on-this-page"></div>
         </nav>
       </aside>
       {{ end }}

--- a/layouts/partials/site/header.html
+++ b/layouts/partials/site/header.html
@@ -1,41 +1,19 @@
-<header id="main-header" class="site-menu-wrapper site-header site-header--fixed background-purple p-3 flex--align-center flex--justify-start">
-  <a href="/" class="site-logo mr-3">
+<header id="main-header" class="site-header site-header--fixed background-purple block-container px-4">
+  <a href="/" class="site-logo h-100 flex flex--align-center flex--justify-center">
     <img src="/images/platform-ui.svg" alt="Platform UI" />
   </a>
-  <button title="Toggle Navigation" aria-label="Toggle Navigation" class="site-menu-mobile-action button--plain text-white pos-abs pin-right pin-center-top mr-3">
-    <span aria-hidden="true" class="mobile-action__line"></span>
-  </button>
-  <nav class="site-menu hover-underline hover-underline--white text-white">
+  <nav class="site-menu hover-underline hover-underline--white h-100 flex flex--grow flex--align-center text-white px-2">
     {{ $currentPage := . }}
     {{ $currentSection := $currentPage.Section }}
     {{ range .Site.Menus.main }}
       {{ $active := eq $currentSection .Identifier }}
-      {{ if .HasChildren }}
-      <div class="no-border dropdown p-3">
-        <a href="{{ .URL }}" class="site-menu__item dropdown__trigger flex flex--justify-between w-100{{ if $active }} active{{ end }}">
-          {{ .Name }} <i class="pi-angle-right ml-2 site-menu__link-icon"></i>
-        </a>
-        <div class="dropdown__content background-purple">
-          <ul class="pui-list">
-            {{ range .Children }}
-            <li class="m-0">
-              <a href="{{ .URL }}" class="w-100 px-3 py-2 flex">{{ .Name }}</a>
-            </li>
-            {{ end }}
-          </ul>
-        </div>
-      </div>
-      {{ else }}
-        <a href="{{ .URL }}" class="site-menu__item{{ if $active }} active{{end}}">{{ .Name }}</a>
-      {{ end }}
+        <a class="p-2 text-white site-menu__item{{ if $active }} active{{end}}" href="{{ .URL }}" >{{ .Name }}</a>
     {{ end }}
   </nav>
-  <div class="block-container flex--grow">
-    <div class="block block-10 tablet-up-11 lg-tablet-up-12 text-white flex flex--justify-end flex--align-center">
-      <span class="mr-3">v1.1</span>
-      <a href="https://rimdev.io" class="mr-3 text-white" title="RIMdev Blog" aria-label="RIMdev Blog">
-        <i class='pi-rimdev-circle pi-xl text-skyblue--hover' aria-hidden="true"></i>
-      </a>
-    </div>
+  <div class="h-100 text-white flex flex--justify-end flex--align-center">
+    <span class="mr-2">v1.1</span>
+    <a href="https://rimdev.io" class="text-white" title="RIMdev Blog" aria-label="RIMdev Blog">
+      <i class='pi-rimdev-circle pi-xl text-skyblue--hover' aria-hidden="true"></i>
+    </a>
   </div>
 </header>


### PR DESCRIPTION
Issue:
#123 

Updates:
- Removed "Table of Contents" button and replaced with a mobile menu button
- Fixed "On this page" section to display under page heading on mobile
- Changed main navigation to always display links, no longer has dropdown menu
- Updated link styles
  - External links have icon to indicate they are external, also open in new tab
  - Changed site link color to purple, underlined
- Updated headers
  - Changed to purple
  - Content section headers are now links, included hover styles

Screenshots:
Updated responsive view
<img width="416" alt="Screen Shot 2022-03-23 at 10 21 15 AM" src="https://user-images.githubusercontent.com/5217768/159721278-f71dd154-3d8e-46d9-acef-505c33a96b30.png">

Navigation open
<img width="425" alt="Screen Shot 2022-03-23 at 10 24 51 AM" src="https://user-images.githubusercontent.com/5217768/159721973-1f3eccf4-7412-4354-97d3-e0a04b97669c.png">

Header link, hovered 
<img width="138" alt="Screen Shot 2022-03-23 at 10 25 25 AM" src="https://user-images.githubusercontent.com/5217768/159722071-2bec3ba2-920a-4dcf-af33-61a50fc82e03.png">