### PR TITLE
Lock CDN Version to 1.3.7

### DIFF
--- a/layouts/partials/head/styles.html
+++ b/layouts/partials/head/styles.html
@@ -1,6 +1,6 @@
 
 <link href="https://fonts.googleapis.com/css2?family=Nunito+Sans:ital,wght@0,400;0,700;1,400&family=Roboto+Slab:wght@700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="https://unpkg.com/@ritterim/platform-ui/dist/platform-ui.min.css">
+<link rel="stylesheet" href="https://unpkg.com/@ritterim/platform-ui@1.3.7/dist/platform-ui.min.css">
 {{ if .Page.Params.SkellyCSS }}
 <link rel="stylesheet" href="https://unpkg.com/@ritterim/skellycss/dist/style.css">
 {{ end }}

--- a/layouts/partials/site/scripts.html
+++ b/layouts/partials/site/scripts.html
@@ -1,4 +1,4 @@
-<script src="https://unpkg.com/@ritterim/platform-ui/dist/js/platform-ui.min.js" crossorigin defer></script>
+<script src="https://unpkg.com/@ritterim/platform-ui@1.3.7/dist/js/platform-ui.min.js" crossorigin defer></script>
 {{ if .Page.Params.SkellyCSS }}
 <script type="text/javascript" src="https://unpkg.com/@ritterim/skellycss/dist/skelly.js" crossorigin defer></script>
 {{ end }}


### PR DESCRIPTION
Issue:
#144 

Updates:
- Locks CDN version to `1.3.7` to prepare for update to `1.4.0`