### PR TITLE
Update calm-meadow to deploy to dev

### DIFF
--- a/.github/workflows/azure-static-web-apps-calm-meadow-0eb64ed0f.yml
+++ b/.github/workflows/azure-static-web-apps-calm-meadow-0eb64ed0f.yml
@@ -1,14 +1,14 @@
 # Deploys to development: pui.rimdev.io
-name: Azure Static Web Apps CI/CD
+name: Deploy to Development
 
 on:
   push:
     branches:
-      - master
+      - development
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
-      - master
+      - development
 
 jobs:
   build_and_deploy_job:


### PR DESCRIPTION
- We need to deploy on merges to the `development` branch.
- The secret in use is `AZURE_STATIC_WEB_APPS_API_TOKEN_CALM_MEADOW_0EB64ED0F`.
