### PR TITLE
Add z-index utility to docs

### DIFF
--- a/content/docs/utilities/z-index.md
+++ b/content/docs/utilities/z-index.md
@@ -1,0 +1,135 @@
+---
+title: Z-Index
+skellyCSS: true
+---
+
+{{% anchor name="Z-Index" %}}
+
+{{< classes result="true" >}}
+{{< classes-row class="z-0" result="z-index: 0" >}}
+{{< classes-row class="z-10" result="z-index: 10" >}}
+{{< classes-row class="z-20" result="z-index: 20" >}}
+{{< classes-row class="z-30" result="z-index: 30" >}}
+{{< classes-row class="z-40" result="z-index: 40" >}}
+{{< classes-row class="z-50" result="z-index: 50" >}}
+{{< classes-row class="z-60" result="z-index: 60" >}}
+{{< classes-row class="z-70" result="z-index: 70" >}}
+{{< classes-row class="z-80" result="z-index: 80" >}}
+{{< classes-row class="z-90" result="z-index: 90" >}}
+{{< classes-row class="z-100" result="z-index: 100" >}}
+{{< classes-row class="-z-10" result="z-index: -10" >}}
+{{< classes-row class="-z-20" result="z-index: -20" >}}
+{{< classes-row class="z-auto" result="z-index: auto" >}}
+{{< /classes >}}
+
+{{< code-demo >}}
+<div class="rounded-2 block background--dark p-3">
+  <div class="flex">
+    <div 
+      class="pos-rel z-30 background--lavender text--purple text--bold border border--color-white border--width-2 flex--center-content" 
+      style="border-radius: 50%; height: 5rem; width: 5rem;">
+      z-30
+    </div>
+    <div 
+      class="pos-rel z-40 background--light-purple text--white text--bold border border--color-white border--width-2 flex--center-content" 
+      style="border-radius: 50%; height: 5rem; width: 5rem; margin-left: -1rem">
+      z-40
+    </div>
+    <div 
+      class="pos-rel z-50 background--purple text--white text--bold border border--color-white border--width-2 flex--center-content" 
+      style="border-radius: 50%; height: 5rem; width: 5rem; margin-left: -1rem">
+      z-50
+    </div>
+    <div 
+      class="pos-rel z-40 background--light-purple text--white text--bold border border--color-white border--width-2 flex--center-content" 
+      style="border-radius: 50%; height: 5rem; width: 5rem; margin-left: -1rem">
+      z-40
+    </div>
+    <div 
+      class="pos-rel z-30 background--lavender text--purple text--bold border border--color-white border--width-2 flex--center-content" 
+      style="border-radius: 50%; height: 5rem; width: 5rem; margin-left: -1rem">
+      z-30
+    </div>
+  </div>
+</div>
+{{< /code-demo >}}
+
+{{< code-markup >}}
+{{< highlight html >}}
+<div class="pos-rel z-30">
+  z-30
+</div>
+<div class="pos-rel z-40">
+  z-40
+</div>
+<div class="pos-rel z-50">
+  z-50
+</div>
+<div class="pos-rel z-40">
+  z-40
+</div>
+<div class="pos-rel z-30">
+  z-30
+</div>
+{{< /highlight >}} 
+{{< /code-markup >}}
+
+{{% anchor name="Javascript Option" %}}
+{{% requires-js %}}
+
+{{< code-demo >}}
+<div class="rounded-2 block background--dark p-3">
+  <div class="flex">
+    <div 
+      class="pos-rel background--lavender text--purple text--bold border border--color-white border--width-2 flex--center-content" 
+      style="border-radius: 50%; height: 5rem; width: 5rem;"
+      data-z="31">
+      31
+    </div>
+    <div 
+      class="pos-rel background--light-purple text--white text--bold border border--color-white border--width-2 flex--center-content" 
+      style="border-radius: 50%; height: 5rem; width: 5rem; margin-left: -1rem"
+      data-z="60">
+      60
+    </div>
+    <div 
+      class="pos-rel background--purple text--white text--bold border border--color-white border--width-2 flex--center-content" 
+      style="border-radius: 50%; height: 5rem; width: 5rem; margin-left: -1rem"
+      data-z="999">
+      999
+    </div>
+    <div 
+      class="pos-rel background--light-purple text--white text--bold border border--color-white border--width-2 flex--center-content" 
+      style="border-radius: 50%; height: 5rem; width: 5rem; margin-left: -1rem"
+      data-z="10">
+      10
+    </div>
+    <div 
+      class="pos-rel background--lavender text--purple text--bold border border--color-white border--width-2 flex--center-content" 
+      style="border-radius: 50%; height: 5rem; width: 5rem; margin-left: -1rem"
+      data-z="1">
+      1
+    </div>
+  </div>
+</div>
+{{< /code-demo >}}
+
+{{< code-markup >}}
+{{< highlight html >}}
+<div class="pos-rel z-30" data-z="31">
+  31
+</div>
+<div class="pos-rel z-40" data-z="60">
+  60
+</div>
+<div class="pos-rel z-50" data-z="999">
+  999
+</div>
+<div class="pos-rel z-40" data-z="10">
+  10
+</div>
+<div class="pos-rel z-30" data-z="1">
+  1
+</div>
+{{< /highlight >}} 
+{{< /code-markup >}}

--- a/content/docs/utilities/z-index.md
+++ b/content/docs/utilities/z-index.md
@@ -5,6 +5,8 @@ skellyCSS: true
 
 {{% anchor name="Z-Index" %}}
 
+You can use these utility classes to control the stack. Add a specified `z-{value}` class to your element to change the order of the stack. Remember to specify at least `position: relative` on the element for `z-index` to work.
+
 {{< classes result="true" >}}
 {{< classes-row class="z-0" result="z-index: 0" >}}
 {{< classes-row class="z-10" result="z-index: 10" >}}
@@ -76,6 +78,8 @@ skellyCSS: true
 
 {{% anchor name="Javascript Option" %}}
 {{% requires-js %}}
+
+Can't find the value you need in the list above? You can add a `data-z="{value}"` to your element and let javascript handle the rest. 
 
 {{< code-demo >}}
 <div class="rounded-2 block background--dark p-3">

--- a/content/docs/utilities/z-index.md
+++ b/content/docs/utilities/z-index.md
@@ -5,7 +5,7 @@ skellyCSS: true
 
 {{% anchor name="Z-Index" %}}
 
-You can use these utility classes to control the stack. Add a specified `z-{value}` class to your element to change the order of the stack. Remember to specify at least `position: relative` on the element for `z-index` to work.
+You can use these utility classes to control the stack. Add a `z-{value}` class to your element to change the order of the stack. Remember to specify `position: relative` on the element for `z-index` to work.
 
 {{< classes result="true" >}}
 {{< classes-row class="z-0" result="z-index: 0" >}}

--- a/content/docs/utilities/z-index.md
+++ b/content/docs/utilities/z-index.md
@@ -5,7 +5,7 @@ skellyCSS: true
 
 {{% anchor name="Z-Index" %}}
 
-You can use these utility classes to control the stack. Add a `z-{value}` class to your element to change the order of the stack. Remember to specify `position: relative` on the element for `z-index` to work.
+You can use these utility classes to control elements layered in a stack. Add a `z-{value}` class to your element to change the order of the stack. Remember to specify `position: relative` on the element for `z-index` to work.
 
 {{< classes result="true" >}}
 {{< classes-row class="z-0" result="`z-index: 0`" >}}

--- a/content/docs/utilities/z-index.md
+++ b/content/docs/utilities/z-index.md
@@ -8,20 +8,20 @@ skellyCSS: true
 You can use these utility classes to control the stack. Add a `z-{value}` class to your element to change the order of the stack. Remember to specify `position: relative` on the element for `z-index` to work.
 
 {{< classes result="true" >}}
-{{< classes-row class="z-0" result="z-index: 0" >}}
-{{< classes-row class="z-10" result="z-index: 10" >}}
-{{< classes-row class="z-20" result="z-index: 20" >}}
-{{< classes-row class="z-30" result="z-index: 30" >}}
-{{< classes-row class="z-40" result="z-index: 40" >}}
-{{< classes-row class="z-50" result="z-index: 50" >}}
-{{< classes-row class="z-60" result="z-index: 60" >}}
-{{< classes-row class="z-70" result="z-index: 70" >}}
-{{< classes-row class="z-80" result="z-index: 80" >}}
-{{< classes-row class="z-90" result="z-index: 90" >}}
-{{< classes-row class="z-100" result="z-index: 100" >}}
-{{< classes-row class="-z-10" result="z-index: -10" >}}
-{{< classes-row class="-z-20" result="z-index: -20" >}}
-{{< classes-row class="z-auto" result="z-index: auto" >}}
+{{< classes-row class="z-0" result="`z-index: 0`" >}}
+{{< classes-row class="z-10" result="`z-index: 10`" >}}
+{{< classes-row class="z-20" result="`z-index: 20`" >}}
+{{< classes-row class="z-30" result="`z-index: 30`" >}}
+{{< classes-row class="z-40" result="`z-index: 40`" >}}
+{{< classes-row class="z-50" result="`z-index: 50`" >}}
+{{< classes-row class="z-60" result="`z-index: 60`" >}}
+{{< classes-row class="z-70" result="`z-index: 70`" >}}
+{{< classes-row class="z-80" result="`z-index: 80`" >}}
+{{< classes-row class="z-90" result="`z-index: 90`" >}}
+{{< classes-row class="z-100" result="`z-index: 100`" >}}
+{{< classes-row class="-z-10" result="`z-index: -10`" >}}
+{{< classes-row class="-z-20" result="`z-index: -20`" >}}
+{{< classes-row class="z-auto" result="`z-index: auto`" >}}
 {{< /classes >}}
 
 {{< code-demo >}}

--- a/content/docs/utilities/z-index.md
+++ b/content/docs/utilities/z-index.md
@@ -5,7 +5,7 @@ skellyCSS: true
 
 {{% anchor name="Z-Index" %}}
 
-You can use these utility classes to control elements layered in a stack. Add a `z-{value}` class to your element to change the order of the stack. Remember to specify `position: relative` on the element for `z-index` to work.
+These utility classes control the stacking order within the DOM. Adding a `z-{value}` class to your element will change its order in the stack.
 
 {{< classes result="true" >}}
 {{< classes-row class="z-0" result="`z-index: 0`" >}}


### PR DESCRIPTION
Issue: https://github.com/ritterim/platform-ui/issues/722

<img width="986" alt="Screen Shot 2022-08-02 at 11 29 49 AM" src="https://user-images.githubusercontent.com/5313708/182413363-e82c77a7-bc10-4cbc-9df3-b1776c74b25a.png">
<img width="1024" alt="Screen Shot 2022-08-02 at 11 29 56 AM" src="https://user-images.githubusercontent.com/5313708/182413390-59a35a93-08d7-4b04-af86-47bb990622df.png">

